### PR TITLE
Update PINRemoteImage/iOS version requirement

### DIFF
--- a/ios/FastImage/FFFastImageView.h
+++ b/ios/FastImage/FFFastImageView.h
@@ -3,6 +3,7 @@
 #import "PINRemoteImageManager.h"
 #import <PINRemoteImage/PINImageView+PINRemoteImage.h>
 #import <FLAnimatedImage/FLAnimatedImageView.h>
+#import <FLAnimatedImage/FLAnimatedImage.h>
 
 #import <React/RCTComponent.h>
 #import <React/RCTResizeMode.h>

--- a/react-native-fast-image.podspec
+++ b/react-native-fast-image.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
   s.exclude_files = "ios/Vendor/**/*.{h,m}"
 
   s.dependency 'React'
-  s.dependency 'PINRemoteImage/iOS', '= 3.0.0-beta.13'
+  s.dependency 'PINRemoteImage/iOS', '= 3.0.0-beta.14'
   s.dependency 'PINRemoteImage/PINCache'
   s.dependency 'FLAnimatedImage'
 end

--- a/react-native-fast-image.podspec
+++ b/react-native-fast-image.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
   s.exclude_files = "ios/Vendor/**/*.{h,m}"
 
   s.dependency 'React'
-  s.dependency 'PINRemoteImage/iOS', '= 3.0.0-beta.14'
+  s.dependency 'PINRemoteImage/iOS'
   s.dependency 'PINRemoteImage/PINCache'
   s.dependency 'FLAnimatedImage'
 end


### PR DESCRIPTION
## Summary
- Change PINRemoteImage/iOS version requirement to solve cocoapods conflict with new version of Texture. New version of texture is needed to fix Times New Roman bug on ios 13.
- Edit FFFastImageView.h to import FLAnimatedImage.h to solve error that appears

## Test Plan
Compiled, Build Success on Traveloka RN iOS staging build

## Checklist

- [x] I have tested this changes in simulator or real device
- [ ] This PR contains relevant automated test(s) with my proposed changes
